### PR TITLE
Support example

### DIFF
--- a/lib/swagger_rule.js
+++ b/lib/swagger_rule.js
@@ -11,7 +11,6 @@ module.exports = contract => {
     }
 
     for (let field in definitions[objectName].properties) {
-      delete definitions[objectName].properties[field].example;
       if (definitions[objectName].properties[field].hasOwnProperty('enum')) {
         definitions[objectName].properties[field].type = 'enum';
         definitions[objectName].properties[field]['values'] = definitions[objectName].properties[field].enum;


### PR DESCRIPTION
I just delete the following line
```js
delete definitions[objectName].properties[field].example;
```

I cannot understand why you delete example , it works like a charm