### PR TITLE
Comment apikey

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -27,11 +27,11 @@ exports.swaggerdoc = {
   consumes: ['application/json'],
   produces: ['application/json'],
   securityDefinitions: {
-    apikey: {
-      type: 'apiKey',
-      name: 'clientkey',
-      in: 'header',
-    },
+    // apikey: {
+    //   type: 'apiKey',
+    //   name: 'clientkey',
+    //   in: 'header',
+    // },
     // oauth2: {
     //   type: 'oauth2',
     //   tokenUrl: 'http://petstore.swagger.io/oauth/dialog',


### PR DESCRIPTION
As in eggjs , we have a config merge , it it not possible to enable security without apikey , for instance we have no apikey security but we have oAuth