### PR TITLE
Support type field

### DIFF
--- a/lib/definition_reader.js
+++ b/lib/definition_reader.js
@@ -34,7 +34,7 @@ module.exports = app => {
         let def = require(filepath.split('.js')[0]);
 
         for (let object in def) {
-          if (def[object].hasOwnProperty('type')) {
+          if (def[object].hasOwnProperty('type') && typeof def[object] === 'string') {
             // 兼容之前的版本
             definitions[object] = def[object];
 


### PR DESCRIPTION
Support contract that contains `type` field  , for instance

```js
module.exports = {
  createResource: {
    type: { type: 'string', required: true, example: '1' },
    resourceNametrue: { type: 'string', required: true },
    resourceType: { type: 'string', required: true, enum: ['video', 'game', 'image'] },
    resourceTag: { type: 'array', itemType: 'string' },
    owner: { type: 'User', required: true },
    owners: { type: 'array', itemType: 'User' }
  },
};
```