### PR TITLE
修复子目录扫描结果没有正确合并问题

### DIFF
--- a/lib/document/index.js
+++ b/lib/document/index.js
@@ -79,7 +79,10 @@ function getTag_Path(fileDir, securitys, swagger, definitions) {
     const stat = fs.statSync(filepath);
 
     if (stat.isDirectory()) {
-      getTag_Path(filepath, securitys, swagger, definitions);
+      const subPath = getTag_Path(filepath, securitys, swagger, definitions);
+      // 合并子目录的扫描结果
+      tags.concat(subPath.tags);
+      Object.assign(paths, subPath.paths);
       continue;
     }
 


### PR DESCRIPTION
由于项目需要，controller 具有多层目录结构
```
/controller
      /v1
         /user.js
      /v2
        /user.js
```

看源码已经扫描了多层目录，但是没有将扫描结果正确合并