### PR TITLE
修复扫描没有带 @Controller 标记的文件问题, fix #42

### DIFF
--- a/lib/comment/index.js
+++ b/lib/comment/index.js
@@ -10,11 +10,8 @@ module.exports = {
   generateCommentBlocks: filePath => {
     let buffer = fs.readFileSync(filePath);
     let fileString = buffer.toString();
-    const block_regex = /\/\*\*([\s\S]*?)\*\//gm;
-    let blocks = fileString.match(block_regex).filter(value => {
-      return value.indexOf('ontroller') > -1 || value.indexOf('outer') > -1 || value.indexOf('gnore') > -1;
-    });
-    return blocks;
+    const block_regex = /\/\*\*([\s\S]*?(ontroller|outer|gnore)[\s\S]*?)\*\//gm;
+    return fileString.match(block_regex);
   },
   /**
    * 获取块中包含指定标识的注释行，返回行中以空格分割的得到的数组

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-swagger-doc",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "swagger for egg",
   "eggPlugin": {
     "name": "swaggerdoc"


### PR DESCRIPTION
commit 91073a221110bd 的修复导致 225版本会扫描不带 @controller 标记的文件，导致进程 crash
根据相应逻辑修复对文件扫描的正则表达式处理