### PR TITLE
feat: 添加自定义类型

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -46,6 +46,8 @@ exports.swaggerdoc = {
   // enableValidate: true,
   routerMap: false,
   enable: true,
+  type: ['ISOTime'],
+  itemType: []
 };
 
 exports.security = {

--- a/lib/contract/index.js
+++ b/lib/contract/index.js
@@ -175,6 +175,18 @@ module.exports = {
    * @param {EggApplication} app egg应用
    */
   getDefinitions: app => {
+    const swagger = app.config.swaggerdoc
+    if(swagger.type){
+      swagger.type.forEach(element => {
+        type.push(element)
+      });
+    }
+    if(swagger.itemType){
+      swagger.itemType.forEach(element => {
+        itemType.push(element)
+      });
+    }
+    
     if (!CONTRACT) {
       generateContract(app);
     }


### PR DESCRIPTION
1. 当数值类型非预定义的几种基本类型时，`egg-swagger-doc`会将类型转为`object`，然后为其加上特定的`rule`，但之后使用`egg-validate`时，`this.app.validator.addRule`添加的数据类型校验就无法使用了。
2. 因此，这里通过在配置文件中添加自定义类型名称，跳过转为`object`的操作，将用户自定义的类型像对打基本类型（如`int`）一样，直接传给`egg-validate`，让`validator`使用`this.app.validator.addRule`添加的自定义校验规则去校验。
3. 同时，这样一样来，`egg-swagger-doc`不支持的类型但`egg-validate`支持的类型也可以直接使用了。如`enum`,`egg-swagger-doc`通过转为数组来使用的。
4. 使用方式是这样的：

* 在config.default.js中添加自定义类型（type）或自定义数组元素类型（itemType）的名称

  ```js
  exports.swaggerdoc = {
    dirScanner: './app/controller',
    basePath: '/',
    apiInfo: {
      title: 'egg-swagger',
      description: 'swagger-ui for egg js api',
      version: '1.0.0',
    },
    schemes: ['http', 'https'],
    consumes: ['application/json'],
    produces: ['application/json'],
    enableSecurity: false,
    routerMap: false,
    enable: true,

    // 自定义类型
    type: ['ISOTime’,’enum’],
    // 自定义数组元素类型
    itemType: []
  };

  ```

* 在自己的应用程序中使用 `this.app.validator.addRule`，如：

  ```js
      this.app.validator.addRule('ISOTime', (rule, value) => {
        if (!moment(value, moment.ISO_8601).isValid()) {
          return 'time must be UTC ISO8601 format';
        }
      });

  ```

* 在`contract/request`中可以直接使用类型`ISOTime`和`enum`

  ```js
  module.exports = {
    custClass: {
      time: {
        type: 'ISOTime',
        required: true,
        allowEmpty: false
      },

      dayEnum: {
        type: 'enum',
        values: ['mon', 'tue', 'wed', 'thu', 'fri'],
        default: 'person',
        required: false,
        convertType: 'string'
      }
    }
  }
  ```

issue #46 的需求用这种办法可以实现， #30 的问题也可以解决。