### PR TITLE
fix: 解决使用TypeScript时，生产模式下加载`.ts`文件时报错

### DIFF
--- a/lib/document/index.js
+++ b/lib/document/index.js
@@ -88,6 +88,14 @@ function getTag_Path(fileDir, securitys, swagger, definitions) {
 
     if (stat.isFile() && ['.js', '.ts'].indexOf(path.extname(name)) !== -1) {
 
+      const extname = path.extname(name);
+      if (extname === '.ts') {
+        const jsFile = name.replace('.ts', '.js');
+        if (names.indexOf(jsFile) >= 0) {
+          continue;
+        }
+      }
+
       let blocks = comment.generateCommentBlocks(filepath);
 
       // 如果第一个注释块不包含@controller不对该文件注释解析


### PR DESCRIPTION
在开发模式下`.ts`文件在被`swagger`加载前会在内存中被自动转化为`.js`文件，因此`swagger`加载的文件其实为’.js’文件，不会加载`.ts`文件。
但生产模式下是预先将`.ts`文件转为`.js`文件，同时保留’.ts’文件，`swagger`会同时加载`.ts`和`.js`文件。在加载`.ts`文件时无法解析TypeScript语法，会报错。
解决办法是：
当’.ts’文件存在后缀为`.js`的同名文件时，跳过这个`.ts`文件。即：在生产模式下，跳过所有`.ts`文件；开发模式下不跳过文件。

#54 