### PR TITLE
fix: 修复合并子目录扫描结果的时候 tags 丢失的问题

### DIFF
--- a/lib/document/index.js
+++ b/lib/document/index.js
@@ -81,7 +81,7 @@ function getTag_Path(fileDir, securitys, swagger, definitions) {
     if (stat.isDirectory()) {
       const subPath = getTag_Path(filepath, securitys, swagger, definitions);
       // 合并子目录的扫描结果
-      tags.concat(subPath.tags);
+      tags = tags.concat(subPath.tags);
       Object.assign(paths, subPath.paths);
       continue;
     }


### PR DESCRIPTION
在合并子目录扫描结果的时候， concat() 结果生成新的数组，代码里面没有对新数组进行保存，导致 tags 列表丢失。