### PR TITLE
fix: 解决意外加载TypeScript声明文件`.d.ts`报错问题

### DIFF
--- a/lib/contract/index.js
+++ b/lib/contract/index.js
@@ -47,7 +47,7 @@ function contractLoader(app, baseDir, directory) {
       continue;
     }
 
-    if (stat.isFile() && ['.js', '.ts'].indexOf(path.extname(filepath)) !== -1 && !/.d.ts$/.test(filepath)) {
+    if (stat.isFile() && ['.js', '.ts'].indexOf(path.extname(filepath)) !== -1 && !/\.d\.ts$/.test(filepath)) {
       let def = require(filepath.split(/\.(js|ts)/)[0]);
 
       for (let object in def) {

--- a/lib/contract/index.js
+++ b/lib/contract/index.js
@@ -47,7 +47,7 @@ function contractLoader(app, baseDir, directory) {
       continue;
     }
 
-    if (stat.isFile() && ['.js', '.ts'].indexOf(path.extname(filepath)) !== -1) {
+    if (stat.isFile() && ['.js', '.ts'].indexOf(path.extname(filepath)) !== -1 && !/.d.ts$/.test(filepath)) {
       let def = require(filepath.split(/\.(js|ts)/)[0]);
 
       for (let object in def) {


### PR DESCRIPTION
您好，我使用`egg-swagger-doc`，版本`2.3.2`
问题是这样的。
我使用`eggjs`的`typescript`模板开发项目，安装了`egg-swagger-doc`插件，
`npm run start`报错，错误原因部分提示如下：

```text
2020-07-23 23:07:51,521 ERROR 11668 [-/127.0.0.1/-/1ms GET /] nodejs.MODULE_NOT_FOUNDError: Cannot find module 'E:\personal\glacier\test\fixtures\apps\glacier-demo-ts\app\contract\format.d'
Require stack:
- E:\personal\glacier\node_modules\egg-swagger-doc\lib\contract\index.js
- E:\personal\glacier\node_modules\egg-swagger-doc\app\extend\context.js
```

然后我找到了异常代码：

```js
// egg-swagger-doc\lib\contract\index.js
// 第50、51行
if (stat.isFile() && [ '.js', '.ts' ].indexOf(path.extname(filepath)) !== -1) {
  const def = require(filepath.split(/\.(js|ts)/)[0]);
```

异常的原因是，我的`tsconfig.json`文件声明了`"declaration":true`,在使用`tsc`命令编译`app/contract`目录下的`ts`文件时会生成`.js`文件和`.d.ts`声明文件。

您的代码中会把匹配`.ts`后缀的`.d.ts`文件作为模块使用`require('.d')`加载，而这个文件并不存在，所以报错。

解决方法是跳过`.d.ts`类型的声明文件。
这是我的修复代码。
请尽快修复，祝好。