### PR TITLE
修改bug：在生产环境下[npm start]，产生错误：'controller not exists'

### DIFF
--- a/lib/document/index.js
+++ b/lib/document/index.js
@@ -183,9 +183,9 @@ function hasController(block) {
 function generateAPIFunc(filepath) {
   let func = [];
   let obj = require(filepath);
-  if (path.extname(filepath) === '.ts') {
+  //if (path.extname(filepath) === '.ts') {
     obj = obj.default;
-  }
+  //}
 
   let instance = obj.prototype || obj;
   func = Object.getOwnPropertyNames(instance).map(key => {

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -40,9 +40,9 @@ module.exports = {
       let fileExtname = path.extname(obj.filePath);
       let direct = `${obj.filePath.split(fileExtname)[0].split('app' + path.sep)[1]}`;
 
-      if (fileExtname === '.ts') {
+      //if (fileExtname === '.ts') {
         instance = instance.default;
-      }
+      //}
 
       for (let req of obj.routers) {
 


### PR DESCRIPTION
当前版本tsc编译的js文件也是通过default属性导出类，如下图所示：

![image](https://user-images.githubusercontent.com/1549446/122648312-45e81980-d15b-11eb-99ca-c4201b63f55d.png)